### PR TITLE
change: added ticks min value for bar chart

### DIFF
--- a/src/components/barChart.tsx
+++ b/src/components/barChart.tsx
@@ -28,6 +28,9 @@ const BarChart = ({ data, options }: Props) => {
                     gridLines: {
                       color: "rgba(0, 0, 0, 0)",
                     },
+                    ticks: {
+                      min: 0,
+                    },
                   },
                 ],
               },


### PR DESCRIPTION
Ho aggiungo `ticks.min: 0` per il grafico a barre così si riesce a capire la differenza assoluta da un giorno all'altro, mi sembra più chiaro così.